### PR TITLE
sim_trial check pop variable

### DIFF
--- a/R/sim_trial.R
+++ b/R/sim_trial.R
@@ -120,7 +120,7 @@ sim_trial <- function(pop, h2, n.env = 1, n.rep = 1, check.pop, check.rep, ...) 
   
   # Note the environment variance is 0 so as to add the environmental effects
   # from the previous simulation
-  check_pheno <- sim_phenoval(pop = check_pop, h2 = h2, n.env = n.env, n.rep = check.rep,
+  check_pheno <- sim_phenoval(pop = check.pop, h2 = h2, n.env = n.env, n.rep = check.rep,
                               V_E = V_E, V_R = V_R)
   
   # Extract the phenotypic observations and add the environmental effects


### PR DESCRIPTION
the variable used for check population in this function is check.pop,
an incorrect check_pop variable is used in sim phenoval function, I
would guess this was tested in an environment where check_pop existed
as this variable is used in the example data